### PR TITLE
fix: correct variable reference in parameter parsing logic

### DIFF
--- a/cmd/mcptools/main.go
+++ b/cmd/mcptools/main.go
@@ -687,7 +687,7 @@ func newShellCmd() *cobra.Command { //nolint:gocyclo
 
 					params := map[string]any{}
 					for ii := 1; ii < len(commandArgs); ii++ {
-						if commandArgs[ii] == flagParams || commandArgs[i] == flagParamsShort {
+						if commandArgs[ii] == flagParams || commandArgs[ii] == flagParamsShort {
 							if ii+1 < len(commandArgs) {
 								if jsonErr := json.Unmarshal([]byte(commandArgs[ii+1]), &params); jsonErr != nil {
 									fmt.Fprintf(os.Stderr, "Error: invalid JSON for params: %v\n", jsonErr)


### PR DESCRIPTION
# Description

See #10 for details
Fixes #10

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By running the tool locally:

1. `echo "Hello, World" > ~/file.txt`
2. `make setup & ./bin/mcp shell npx -y @modelcontextprotocol/server-filesystem ~`
3. `call read_file -p {"path":"~/file.txt"}`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    --> Unfortunately, this is not possible with the current unit test setup, because the test reimplements the logic instead of using the actual implementation for this particular case.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 