### PR TITLE
Graceful handling of EOF in mock MCP server

### DIFF
--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -157,9 +157,9 @@ func (s *Server) Start() error {
 		if err := decoder.Decode(&request); err != nil {
 			if err == io.EOF {
 				s.log("Client disconnected (EOF)")
-			} else {
-				s.log(fmt.Sprintf("Error decoding request: %v", err))
+				return nil
 			}
+			s.log(fmt.Sprintf("Error decoding request: %v", err))
 			fmt.Fprintf(os.Stderr, "Error decoding request: %v\n", err)
 			return fmt.Errorf("error decoding request: %w", err)
 		}


### PR DESCRIPTION
# Description

Mock server doesn't work with the mcptools cli, e.g. `mcp shell mcp mock tool mock-test "description"` throws an error:
```
Error connecting to MCP server: command error: exit status 1, stderr: Added tool: mock-test - description
Starting mock MCP server with 1 tool(s), 0 prompt(s), and 0 resource(s)
Use Ctrl+C to exit
Mock server started, waiting for requests...
Waiting for request...
Received request: tools/list (ID: 1)
Sending response
Waiting for request...
Error decoding request: EOF
Error running mock server: error decoding request: EOF
```

In order to fix this, I modified the EOF handling in the `Start()` method to return `nil` instead of an error when EOF is encountered

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run `mcp shell ./bin/mcp mock tool mock-test "maybe-description"` to make sure this fixes the issue described above.
Also added local configuration to claude code to ensure it still works:

```
"mock-test-local": {
  "command": "/path/to/mcptools/bin/mcp",
  "args": [
    "mock",
    "tool",
    "say_hi",
    "\"says hi\""
  ]
}
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 