### PR TITLE
Graceful handling of EOF in MCP proxy server

### DIFF
--- a/cmd/mcptools/main.go
+++ b/cmd/mcptools/main.go
@@ -850,7 +850,7 @@ Available types:
 - prompt <name> <description> <template>
 - resource <uri> <description> <content>
 
-Example: 
+Example:
   mcp mock tool hello_world "when user says hello world, run this tool"
   mcp mock tool hello_world "A greeting tool" \
          prompt welcome "A welcome prompt" "Hello {{name}}, welcome to {{location}}!" \
@@ -1113,7 +1113,7 @@ Example:
 			}
 
 			// Run proxy server
-			fmt.Println("Starting proxy server...")
+			fmt.Fprintln(os.Stderr, "Starting proxy server...")
 			if err := proxy.RunProxyServer(config); err != nil {
 				log.Fatalf("Error running proxy server: %v", err)
 			}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -319,9 +319,9 @@ func (s *Server) Start() error {
 		if err := decoder.Decode(&request); err != nil {
 			if err == io.EOF {
 				s.log("Client disconnected (EOF)")
-			} else {
-				s.log(fmt.Sprintf("Error decoding request: %v", err))
+				return nil
 			}
+			s.log(fmt.Sprintf("Error decoding request: %v", err))
 			fmt.Fprintf(os.Stderr, "Error decoding request: %v\n", err)
 			return fmt.Errorf("error decoding request: %w", err)
 		}
@@ -568,9 +568,9 @@ func RunProxyServer(toolConfigs map[string]map[string]string) error {
 	}
 
 	// Print registered tools
-	fmt.Println("Registered proxy tools:")
+	fmt.Fprintln(os.Stderr, "Registered proxy tools:")
 	for name, tool := range server.tools {
-		fmt.Printf("- %s: %s (script: %s)\n", name, tool.Description, tool.ScriptPath)
+		fmt.Fprintf(os.Stderr, "- %s: %s (script: %s)\n", name, tool.Description, tool.ScriptPath)
 		paramStr := ""
 		for i, param := range tool.Parameters {
 			if i > 0 {
@@ -579,7 +579,7 @@ func RunProxyServer(toolConfigs map[string]map[string]string) error {
 			paramStr += param.Name + ":" + param.Type
 		}
 		if paramStr != "" {
-			fmt.Printf("  Parameters: %s\n", paramStr)
+			fmt.Fprintf(os.Stderr, "  Parameters: %s\n", paramStr)
 		}
 	}
 


### PR DESCRIPTION
# Description

Similar to #13 but for proxy servers.

To reproduce:
```
~ mcp tools mcp proxy start                                
error: command error: exit status 1, stderr: Logging to /Users/alperen/.mcpt/logs/proxy.log
Proxy server started, waiting for requests...
Waiting for request...
Received request: tools/list (ID: 1)
Sending response
Waiting for request...
Error decoding request: EOF
2025/03/29 04:28:32 Error running proxy server: error decoding request: EOF
```

Changes:
- Graceful handling of EOF in MCP proxy server
- Print logs to stderr instead of stdout in main.go and proxy server

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. `make build;./bin/mcp proxy tool add_op "Adds given numbers" "a:int,b:int" -e 'echo "totall is $a + $b = $(($a+$b))"'`
2. `./bin/mcp shell ./bin/mcp proxy start`
3. add_op {"a":1,"b":2}

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 