### PR TITLE
Send initialize request and initialized notification

### DIFF
--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -6,6 +6,10 @@ import (
 	"io"
 )
 
+const (
+	protocolVersion = "2024-11-05"
+)
+
 // Transport defines the interface for communicating with MCP servers.
 // Implementations should handle the specifics of communication protocols.
 type Transport interface {
@@ -17,7 +21,7 @@ type Request struct {
 	Params  any    `json:"params,omitempty"`
 	JSONRPC string `json:"jsonrpc"`
 	Method  string `json:"method"`
-	ID      int    `json:"id"`
+	ID      int    `json:"id,omitempty"`
 }
 
 // Response represents a JSON-RPC 2.0 response.


### PR DESCRIPTION
# Description

MCP protocol requires sending `initialize` message and `initialized` notification to the client. This PR implements this functionality.

**Note:** The implementation sends `initialize` before each command call. For single use commands (`mcp tool`, `mcp resources` etc.) this is not a problem. However that is unnecessary for `mcp shell`, a better way would be to save stdin and stdout streams in the Client and run server command upon client initialization, then send initialize request and notification only once in the client.

Fixes #23 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `make build;./bin/mcp tools npx @jbangdev/jbang jdbc@mcp-java`
- `make build;./bin/mcp tools npx -y @modelcontextprotocol/server-filesystem ~`
- `make build;./bin/mcp shell npx -y @modelcontextprotocol/server-filesystem ~`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 