### PR TITLE
fix(pkg/jsonutils): add description to resource list, unskip test

### DIFF
--- a/cmd/mcptools/commands/resources_test.go
+++ b/cmd/mcptools/commands/resources_test.go
@@ -25,13 +25,13 @@ func TestResourcesCmdRun_Help(t *testing.T) {
 }
 
 func TestResourcesCmdRun_Success(t *testing.T) {
-	t.Skip("Skipping resources command test as resources are not working as expected")
 	// Create a mock client that returns successful response
 	mockResponse := map[string]any{
 		"resources": []any{
 			map[string]any{
-				"uri":         "test-resource",
-				"type":        "text",
+				"uri":         "test://resource",
+				"mimeType":    "text/plain",
+				"name":        "TestResource",
 				"description": "Test resource description",
 			},
 		},
@@ -59,6 +59,8 @@ func TestResourcesCmdRun_Success(t *testing.T) {
 
 	// Verify output contains expected content
 	output := buf.String()
-	assertContains(t, output, "test-resource")
+	assertContains(t, output, "TestResource")
+	assertContains(t, output, "test://resource")
+	assertContains(t, output, "text/plain")
 	assertContains(t, output, "Test resource description")
 }

--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -622,16 +622,23 @@ func formatResourcesList(resources any) (string, error) {
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 	useColors := isTerminal()
 
+	// NOTE: Ensure that the column headers are the same length,
+	//       including the color escape sequences!
 	if useColors {
-		fmt.Fprintf(w, "%s%sNAME%s\t%sTYPE%s\t%sURI%s\n",
-			ColorBold, ColorCyan, ColorReset,
+		fmt.Fprintf(w, "%sNAME%s\t%sMIMETYPE%s\t%sURI%s\t%sDESCRIPTION%s\n",
+			ColorCyan, ColorReset,
+			ColorCyan, ColorReset,
+			ColorCyan, ColorReset,
+			ColorCyan, ColorReset)
+		fmt.Fprintf(w, "%s----%s\t%s--------%s\t%s---%s\t%s----------%s\n",
+			ColorCyan, ColorReset,
+			ColorCyan, ColorReset,
 			ColorCyan, ColorReset,
 			ColorCyan, ColorReset)
 	} else {
-		fmt.Fprintln(w, "NAME\tTYPE\tURI")
+		fmt.Fprintln(w, "NAME\tMIMETYPE\tURI\tDESCRIPTION")
+		fmt.Fprintln(w, "----\t--------\t---\t-----------")
 	}
-
-	fmt.Fprintln(w, "----\t----\t---")
 
 	for _, r := range resourcesSlice {
 		resource, ok1 := r.(map[string]any)
@@ -640,17 +647,22 @@ func formatResourcesList(resources any) (string, error) {
 		}
 
 		name, _ := resource["name"].(string)
-		resType, _ := resource["type"].(string)
+		mimeType, _ := resource["mimeType"].(string)
 		uri, _ := resource["uri"].(string)
+		desc, _ := resource["description"].(string)
+		if len(desc) > 50 {
+			desc = desc[:47] + "..."
+		}
 
 		// Use the entire URI instead of truncating
 		if useColors {
-			fmt.Fprintf(w, "%s%s%s\t%s%s\t%s%s%s\n",
+			fmt.Fprintf(w, "%s%s%s\t%s%s%s\t%s%s%s\t%s\n",
 				ColorGreen, name, ColorReset,
-				resType, ColorReset,
-				ColorYellow, uri, ColorReset)
+				ColorGreen, mimeType, ColorReset,
+				ColorYellow, uri, ColorReset,
+				desc)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", name, resType, uri)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, mimeType, uri, desc)
 		}
 	}
 


### PR DESCRIPTION
While investigating a separate issue (PR incoming), I noticed that the `TestResourcesCmdRun_Success` had been recently skipped. This led me down a small rabbit hole of fixing up the output of that command.

Here's what I changed:

* `pkg/jsonutils`:
  * Adds `description` field to the output of the `resources` command, which was the original reason for the test being skipped.
  * Modifies `formatResourcesList` to correctly align with and without coloured output (pet peeve). The main thing to note here is that `text/tabwriter`'s elastic tabstop algorithm still considers colour escape sequences as part of the 'cells', so it's important to take the length of those sequences into account. I ended up also colouring the second line of the output, ~but can keep it uncoloured if you prefer~ (EDIT: this might not be as straightforward as I originally thought).
  * Renames the `type` field of the `resources` command to the correct `mimeType`.
* `cmd/mcptools/commands`:
  * Updates and un-skips the test `TestResourcesCmdRun_Success`.

The below sample output is from an MCP server I am currently working on.

**Before:**

```
NAME               TYPE  URI
----                            ----           ---
Coder User By ID                  coder://user/{id}
Coder Templates                   coder://templates
Coder Workspaces                  coder://workspaces{?limit,offset,owner}
Coder Workspace by ID             coder://workspace/{id}
```

**After:**
```
NAME                   MIMETYPE          URI                                      DESCRIPTION
----                   --------          ---                                      ----------
Coder User By ID       application/json  coder://user/{id}                        Information about a given Coder user. The strin...
Coder Templates        application/json  coder://templates                        List of all Coder templates available to the cu...
Coder Workspaces       application/json  coder://workspaces{?limit,offset,owner}  List of Coder workspaces with optional filterin...
Coder Workspace by ID  application/json  coder://workspace/{id}                   Detailed information about a specific Coder wor..
```