### PR TITLE
Fix `read-resource` command returning "Error: invalid JSON for params: invalid character %q looking for beginning of value"

### DIFF
--- a/cmd/mcptools/commands/read_resource.go
+++ b/cmd/mcptools/commands/read_resource.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -63,14 +61,6 @@ func ReadResourceCmd() *cobra.Command {
 					"Example: mcp read-resource npx -y @modelcontextprotocol/server-filesystem ~",
 				)
 				os.Exit(1)
-			}
-
-			var params map[string]any
-			if len(parsedArgs) > 0 {
-				if jsonErr := json.Unmarshal([]byte(strings.Join(parsedArgs, " ")), &params); jsonErr != nil {
-					fmt.Fprintf(os.Stderr, "Error: invalid JSON for params: %v\n", jsonErr)
-					os.Exit(1)
-				}
 			}
 
 			mcpClient, clientErr := CreateClientFunc(parsedArgs)

--- a/cmd/mcptools/commands/read_resource_test.go
+++ b/cmd/mcptools/commands/read_resource_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestResourceReadCmd_RunHelp(t *testing.T) {
+	// Given: the read resource command is run
+	cmd := ReadResourceCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	// When: the command is run with the help flag
+	cmd.SetArgs([]string{"--help"})
+
+	// Then: no error is returned.
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("cmd.Execute() error = %v", err)
+	}
+
+	// Then: the help output is not empty.
+	if buf.String() == "" {
+		t.Error("Expected help output to not be empty.")
+	}
+}
+
+func TestReadResourceCmdRun_Success(t *testing.T) {
+	t.Setenv("COLS", "120")
+	// Given: the read resource command is run
+	cmd := ReadResourceCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	// NOTE: we currently truncate output in tabular output.
+	cmd.SetArgs([]string{"server", "-f", "json", "arg"})
+
+	// Given: a mock client that returns a successful read resource response
+	mockResponse := map[string]any{
+		"result": map[string]any{
+			"contents": []any{
+				map[string]any{
+					"uri":      "test://foo",
+					"mimeType": "text/plain",
+					"text":     "bar",
+				},
+			},
+		},
+	}
+
+	cleanup := setupMockClient(func(method string, _ any) (map[string]any, error) {
+		if method != "resources/read" {
+			t.Errorf("Expected method 'resources/read', got %q", method)
+		}
+		return mockResponse, nil
+	})
+	defer cleanup()
+
+	// When: the command is executed
+	err := cmd.Execute()
+
+	// Then: no error is returned
+	if err != nil {
+		t.Errorf("cmd.Execute() error = %v", err)
+	}
+
+	// Then: the expected content is returned
+	output := buf.String()
+	assertContains(t, output, "test://foo")
+	assertContains(t, output, "text/plain")
+	assertContains(t, output, "bar")
+}

--- a/cmd/mcptools/commands/read_resource_test.go
+++ b/cmd/mcptools/commands/read_resource_test.go
@@ -58,7 +58,6 @@ func TestReadResourceCmdRun_Success(t *testing.T) {
 
 	// When: the command is executed
 	err := cmd.Execute()
-
 	// Then: no error is returned
 	if err != nil {
 		t.Errorf("cmd.Execute() error = %v", err)

--- a/pkg/jsonutils/jsonutils.go
+++ b/pkg/jsonutils/jsonutils.go
@@ -766,14 +766,16 @@ func formatGenericMap(data map[string]any) (string, error) {
 	useColors := isTerminal()
 
 	if useColors {
-		fmt.Fprintf(w, "%s%sKEY%s\t%sVALUE%s\n",
-			ColorBold, ColorCyan, ColorReset,
+		fmt.Fprintf(w, "%sKEY%s\t%sVALUE%s\n",
+			ColorCyan, ColorReset,
+			ColorCyan, ColorReset)
+		fmt.Fprintf(w, "%s---%s\t%s-----%s\n",
+			ColorCyan, ColorReset,
 			ColorCyan, ColorReset)
 	} else {
 		fmt.Fprintln(w, "KEY\tVALUE")
+		fmt.Fprintln(w, "---\t-----")
 	}
-
-	fmt.Fprintln(w, "---\t-----")
 
 	keys := make([]string, 0, len(data))
 	for k := range data {


### PR DESCRIPTION
While attempting to use the `read-resource` command to troubleshoot an issue with an MCP server I am currently working on, I was seeing the following error (mcptools dev@5d86d52):

```
$ mcptools read-resource 'coder://user/me' path/to/my/mcp/server
Error: invalid JSON for params: invalid character 'p' looking for beginning of value
```

Upon closer inspection, it appears the `read-resource` command was trying to marshal the required commands to run the given MCP server as JSON. I could not find any reason to do this -- it seems to have been an errant copy-pasta after recent refactors? After removing it, the command worked for me. I also fixed up a couple of other things while I was in the area.

* `cmd/mcptools/commands`:
  * Removes errant `json.Unmarshal` of `parsedArgs` in `ReadResourceCmd()`
  * Adds test for `ReadResourceCmd()`
* `pkg/jsonutils`:
  * Fixes incorrect column alignment in `formatGenericMap()` due to colour escape sequences.
