### PR TITLE
Do not print template name for the version command.

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - master
     paths:
       - '**.go'
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - master
     tags-ignore:
       - '**'
     paths:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - master
     tags-ignore:
       - '**'
     paths:

--- a/cmd/mcptools/commands/version.go
+++ b/cmd/mcptools/commands/version.go
@@ -20,8 +20,6 @@ func VersionCmd() *cobra.Command {
 		Short: "Print the version information",
 		Run: func(cmd *cobra.Command, _ []string) {
 			fmt.Fprintf(cmd.OutOrStdout(), "MCP Tools version %s\n", Version)
-			// print build parameters
-			fmt.Fprintf(cmd.OutOrStdout(), "	Templates path: %s\n", TemplatesPath)
 		},
 	}
 }


### PR DESCRIPTION
# Description
Version test is failing because version commands prints the template path which is unnecessary.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)