### PR TITLE
Keep standard I/O process running in shell mode

### DIFF
--- a/cmd/mcptools/commands/shell.go
+++ b/cmd/mcptools/commands/shell.go
@@ -44,7 +44,7 @@ func ShellCmd() *cobra.Command { //nolint:gocyclo
 				os.Exit(1)
 			}
 
-			mcpClient, clientErr := CreateClientFunc(parsedArgs)
+			mcpClient, clientErr := CreateClientFunc(parsedArgs, client.CloseTransportAfterExecute(false))
 			if clientErr != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", clientErr)
 				os.Exit(1)

--- a/cmd/mcptools/commands/test_helpers.go
+++ b/cmd/mcptools/commands/test_helpers.go
@@ -30,7 +30,7 @@ func setupMockClient(executeFunc func(method string, _ any) (map[string]any, err
 	mockClient := client.NewWithTransport(mockTransport)
 
 	// Override the function that creates clients
-	CreateClientFunc = func(_ []string) (*client.Client, error) {
+	CreateClientFunc = func(_ []string, _ ...client.Option) (*client.Client, error) {
 		return mockClient, nil
 	}
 

--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -17,7 +17,7 @@ var (
 
 // CreateClientFunc is the function used to create MCP clients.
 // This can be replaced in tests to use a mock transport.
-var CreateClientFunc = func(args []string) (*client.Client, error) {
+var CreateClientFunc = func(args []string, opts ...client.Option) (*client.Client, error) {
 	if len(args) == 0 {
 		return nil, ErrCommandRequired
 	}
@@ -42,7 +42,13 @@ var CreateClientFunc = func(args []string) (*client.Client, error) {
 		return client.NewHTTP(args[0]), nil
 	}
 
-	return client.NewStdio(args), nil
+	c := client.NewStdio(args)
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
 }
 
 // ProcessFlags processes command line flags, sets the format option, and returns the remaining

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,17 @@ type Client struct {
 // configuration.
 type Option func(*Client)
 
+// CloseTransportAfterExecute allows keeping a transport alive if supported by
+// the transport.
+func CloseTransportAfterExecute(closeTransport bool) Option {
+	return func(c *Client) {
+		t, ok := c.transport.(interface{ SetCloseAfterExecute(bool) })
+		if ok {
+			t.SetCloseAfterExecute(closeTransport)
+		}
+	}
+}
+
 // NewWithTransport creates a new MCP client using the provided transport.
 // This allows callers to provide a custom transport implementation.
 func NewWithTransport(t transport.Transport) *Client {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,10 @@ type Client struct {
 	transport transport.Transport
 }
 
+// Option provides a way for passing options to the Client to change its
+// configuration.
+type Option func(*Client)
+
 // NewWithTransport creates a new MCP client using the provided transport.
 // This allows callers to provide a custom transport implementation.
 func NewWithTransport(t transport.Transport) *Client {

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -67,12 +67,13 @@ func (t *Stdio) Execute(method string, params any) (map[string]any, error) {
 	if sendErr := t.sendRequest(stdin, request); sendErr != nil {
 		return nil, sendErr
 	}
-	_ = stdin.Close()
 
 	response, err := t.readResponse(stdout)
 	if err != nil {
 		return nil, err
 	}
+
+	_ = stdin.Close()
 
 	// Wait for the command to finish with a timeout to prevent zombie processes
 	done := make(chan error, 1)

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -84,6 +84,16 @@ func (t *Stdio) Execute(method string, params any) (map[string]any, error) {
 		return nil, err
 	}
 
+	err = t.closeProcess(process)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Result, nil
+}
+
+// closeProcess waits for the command to finish, returning any error.
+func (t *Stdio) closeProcess(process *stdioProcess) error {
 	_ = process.stdin.Close()
 
 	// Wait for the command to finish with a timeout to prevent zombie processes
@@ -102,7 +112,7 @@ func (t *Stdio) Execute(method string, params any) (map[string]any, error) {
 		}
 
 		if waitErr != nil && process.stderrBuf.Len() > 0 {
-			return nil, fmt.Errorf("command error: %w, stderr: %s", waitErr, process.stderrBuf.String())
+			return fmt.Errorf("command error: %w, stderr: %s", waitErr, process.stderrBuf.String())
 		}
 	case <-time.After(1 * time.Second):
 		if t.debug {
@@ -112,7 +122,7 @@ func (t *Stdio) Execute(method string, params any) (map[string]any, error) {
 		_ = process.cmd.Process.Kill()
 	}
 
-	return response.Result, nil
+	return nil
 }
 
 // setupCommand prepares and starts the command, returning the stdin/stdout pipes and any error.


### PR DESCRIPTION
# Description

I'm working on an MCP tool which takes a while to boot.

When interacting with this tool through the standard I/O transport, this means that each new request takes a while to complete. That makes the interactive shell mode slower than it needs to be.

This change introduces an option for not closing the process after each request. (The SSE transport will already keep the connection alive.)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Outside running the tests, I have used this locally with `mcptools shell <command>`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~