### PR TITLE
Send init request only once

### DIFF
--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -34,7 +34,8 @@ var CreateClientFunc = func(args []string, opts ...client.Option) (*client.Clien
 				return client.NewHTTP(server), nil
 			}
 			cmdParts := client.ParseCommandString(server)
-			return client.NewStdio(cmdParts), nil
+			c := client.NewStdio(cmdParts, opts...)
+			return c, nil
 		}
 	}
 
@@ -42,11 +43,7 @@ var CreateClientFunc = func(args []string, opts ...client.Option) (*client.Clien
 		return client.NewHTTP(args[0]), nil
 	}
 
-	c := client.NewStdio(args)
-
-	for _, opt := range opts {
-		opt(c)
-	}
+	c := client.NewStdio(args, opts...)
 
 	return c, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,10 +43,14 @@ func NewWithTransport(t transport.Transport) *Client {
 
 // NewStdio creates a new MCP client that communicates with a command
 // via stdin/stdout using JSON-RPC.
-func NewStdio(command []string) *Client {
-	return &Client{
+func NewStdio(command []string, opts ...Option) *Client {
+	c := &Client{
 		transport: transport.NewStdio(command),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // NewHTTP creates a MCP client that communicates with a server via HTTP using JSON-RPC.


### PR DESCRIPTION
# Description

Follow up for #36

- Fixes the issue that causes aliases to not be able to use options.
- Send initialize request only once per process.