### PR TITLE
Add --server-logs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,16 @@ mcp tools npx -y @modelcontextprotocol/server-filesystem ~
 The default format now displays tools in a colorized man-page style:
 
 ```
-read_file(path:str, [limit:int], [offset:int])
-     Reads a file from the filesystem
-
+read_file(path:str)
+     Read the complete contents of a file from the file system.
+read_multiple_files(paths:str[])
+     Read the contents of multiple files simultaneously.
 list_dir(path:str)
-     Lists directory contents
-
+     Lists the contents of a directory.
+write_file(path:str, content:str)
+     Writes content to a file.
 grep_search(pattern:str, [excludePatterns:str[]])
-     Search files with pattern
-
+     Search files with pattern.
 edit_file(edits:{newText:str,oldText:str}[], path:str)
      Edit a file with multiple text replacements
 ```
@@ -236,7 +237,7 @@ mcp call read_file --params '{"path":"/path/to/file"}' npx -y @modelcontextproto
 mcp call resource:test://static/resource/1 npx -y @modelcontextprotocol/server-everything -f json | jq ".contents[0].text"
 ```
 
-or 
+or
 
 ```bash
 mcp read-resource test://static/resource/1 npx -y @modelcontextprotocol/server-everything -f json | jq ".contents[0].text"
@@ -247,6 +248,28 @@ mcp read-resource test://static/resource/1 npx -y @modelcontextprotocol/server-e
 ```bash
 mcp get-prompt simple_prompt npx -y @modelcontextprotocol/server-everything -f json | jq ".messages[0].content.text"
 ```
+
+#### Viewing Server Logs
+
+When using client commands that make calls to the server, you can add the `--server-logs` flag to see the server logs related to your request:
+
+```bash
+# View server logs when listing tools
+mcp tools --server-logs npx -y @modelcontextprotocol/server-filesystem ~
+```
+
+Output:
+```
+[>] Secure MCP Filesystem Server running on stdio
+[>] Allowed directories: [ '/Users/fka/' ]
+read_file(path:str)
+     Read the complete contents of a file from the file system.
+read_multiple_files(paths:str[])
+     Read the contents of multiple files simultaneously.
+... and the other tools available on this server
+```
+
+This can be helpful for debugging or understanding what's happening on the server side when executing these commands.
 
 ### Interactive Shell
 
@@ -330,7 +353,7 @@ After scaffolding, you can build and run your MCP server:
 npm install
 
 # Build the TypeScript code
-npm run build 
+npm run build
 
 # Test the server with MCP Tools
 mcp tools node build/index.js

--- a/cmd/mcptools/commands/get_prompt.go
+++ b/cmd/mcptools/commands/get_prompt.go
@@ -45,6 +45,9 @@ func GetPromptCmd() *cobra.Command {
 				case (cmdArgs[i] == FlagParams || cmdArgs[i] == FlagParamsShort) && i+1 < len(cmdArgs):
 					ParamsString = cmdArgs[i+1]
 					i += 2
+				case cmdArgs[i] == FlagServerLogs:
+					ShowServerLogs = true
+					i++
 				case !promptExtracted:
 					promptName = cmdArgs[i]
 					promptExtracted = true

--- a/cmd/mcptools/commands/read_resource.go
+++ b/cmd/mcptools/commands/read_resource.go
@@ -24,7 +24,7 @@ func ReadResourceCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "Error: resource name is required")
 				fmt.Fprintln(
 					os.Stderr,
-					"Example: mcp read-resource npx -y @modelcontextprotocol/server-filesystem ~",
+					"Example: mcp read-resource test://static/resource/1 npx -y @modelcontextprotocol/server-filesystem ~",
 				)
 				os.Exit(1)
 			}
@@ -58,7 +58,7 @@ func ReadResourceCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "Error: resource name is required")
 				fmt.Fprintln(
 					os.Stderr,
-					"Example: mcp read-resource npx -y @modelcontextprotocol/server-filesystem ~",
+					"Example: mcp read-resource test://static/resource/1 npx -y @modelcontextprotocol/server-filesystem ~",
 				)
 				os.Exit(1)
 			}

--- a/cmd/mcptools/commands/root.go
+++ b/cmd/mcptools/commands/root.go
@@ -15,6 +15,7 @@ const (
 	FlagParamsShort = "-p"
 	FlagHelp        = "--help"
 	FlagHelpShort   = "-h"
+	FlagServerLogs  = "--server-logs"
 )
 
 // entity types.
@@ -31,6 +32,8 @@ var (
 	FormatOption = "table"
 	// ParamsString is the params for the command.
 	ParamsString string
+	// ShowServerLogs is a flag to show server logs.
+	ShowServerLogs bool
 )
 
 // RootCmd creates the root command.

--- a/cmd/mcptools/commands/shell.go
+++ b/cmd/mcptools/commands/shell.go
@@ -30,10 +30,14 @@ func ShellCmd() *cobra.Command { //nolint:gocyclo
 			parsedArgs := []string{}
 
 			for i := 0; i < len(cmdArgs); i++ {
-				if (cmdArgs[i] == FlagFormat || cmdArgs[i] == FlagFormatShort) && i+1 < len(cmdArgs) {
+				switch {
+				case (cmdArgs[i] == FlagFormat || cmdArgs[i] == FlagFormatShort) && i+1 < len(cmdArgs):
 					FormatOption = cmdArgs[i+1]
 					i++
-				} else {
+				case cmdArgs[i] == FlagServerLogs:
+					ShowServerLogs = true
+					i++
+				default:
 					parsedArgs = append(parsedArgs, cmdArgs[i])
 				}
 			}

--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -27,6 +27,8 @@ var CreateClientFunc = func(args []string, opts ...client.Option) (*client.Clien
 		return nil, ErrCommandRequired
 	}
 
+	opts = append(opts, client.SetShowServerLogs(ShowServerLogs))
+
 	// Check if the first argument is an alias
 	if len(args) == 1 {
 		server, found := alias.GetServerCommand(args[0])
@@ -64,6 +66,9 @@ func ProcessFlags(args []string) []string {
 		case (args[i] == FlagFormat || args[i] == FlagFormatShort) && i+1 < len(args):
 			FormatOption = args[i+1]
 			i += 2
+		case args[i] == FlagServerLogs:
+			ShowServerLogs = true
+			i++
 		default:
 			parsedArgs = append(parsedArgs, args[i])
 			i++

--- a/cmd/mcptools/commands/utils_test.go
+++ b/cmd/mcptools/commands/utils_test.go
@@ -21,42 +21,56 @@ func TestProcessFlags(t *testing.T) {
 		args       []string
 		wantArgs   []string
 		wantFormat string
+		showLogs   bool
 	}{
 		{
 			name:       "no flags",
 			args:       []string{"cmd", "arg1", "arg2"},
 			wantArgs:   []string{"cmd", "arg1", "arg2"},
 			wantFormat: "",
+			showLogs:   false,
 		},
 		{
 			name:       "with long format flag",
 			args:       []string{"cmd", "--format", "json", "arg1"},
 			wantArgs:   []string{"cmd", "arg1"},
 			wantFormat: "json",
+			showLogs:   false,
 		},
 		{
 			name:       "with short format flag",
 			args:       []string{"cmd", "-f", "pretty", "arg1"},
 			wantArgs:   []string{"cmd", "arg1"},
 			wantFormat: "pretty",
+			showLogs:   false,
 		},
 		{
 			name:       "with format flag at end",
 			args:       []string{"cmd", "arg1", "--format", "table"},
 			wantArgs:   []string{"cmd", "arg1"},
 			wantFormat: "table",
+			showLogs:   false,
 		},
 		{
 			name:       "with invalid format option",
 			args:       []string{"cmd", "--format", "invalid", "arg1"},
 			wantArgs:   []string{"cmd", "arg1"},
 			wantFormat: "invalid",
+			showLogs:   false,
 		},
 		{
 			name:       "with format flag without value",
 			args:       []string{"cmd", "--format", "json"},
 			wantArgs:   []string{"cmd"},
 			wantFormat: "json",
+			showLogs:   false,
+		},
+		{
+			name:       "with server logs flag",
+			args:       []string{"cmd", "--server-logs", "arg1"},
+			wantArgs:   []string{"cmd", "arg1"},
+			wantFormat: "",
+			showLogs:   true,
 		},
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,6 +33,16 @@ func CloseTransportAfterExecute(closeTransport bool) Option {
 	}
 }
 
+// SetShowServerLogs sets whether to show server logs.
+func SetShowServerLogs(showLogs bool) Option {
+	return func(c *Client) {
+		t, ok := c.transport.(interface{ SetShowServerLogs(bool) })
+		if ok {
+			t.SetShowServerLogs(showLogs)
+		}
+	}
+}
+
 // NewWithTransport creates a new MCP client using the provided transport.
 // This allows callers to provide a custom transport implementation.
 func NewWithTransport(t transport.Transport) *Client {


### PR DESCRIPTION
# Description

Fixes #31

Old: 
```
~ mcp tools npx -y @modelcontextprotocol/server-filesystem ~

read_file(path:str)
     Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read.
     Use this tool when you need to examine the contents of a single file. Only works within allowed directories.
     .
     .
     .
```

New: 
```
~ mcp tools --server-logs npx -y @modelcontextprotocol/server-filesystem ~

[>] Secure MCP Filesystem Server running on stdio
[>] Allowed directories: [ '/Users/alperen' ]
read_file(path:str)
     Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read.
     Use this tool when you need to examine the contents of a single file. Only works within allowed directories.
     .
     .
     .
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests and run local mcp with changes.
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 