### PR TITLE
Basic support for ImageContent (png) in proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,8 @@ This new format clearly shows what parameters each tool accepts, making it easie
 2. Start the proxy server, which implements the MCP protocol
 3. When a tool is called, parameters are passed as environment variables to the script/command
 4. The script/command's output is returned as the tool response
+5.  If the script's output is a base64-encoded PNG image (prefixed with `data:image/png;base64,`), it is returned as an [ImageContent](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#image-content) object.
+
 
 #### Example Scripts and Commands
 
@@ -597,6 +599,16 @@ fi
 # Perform the addition
 result=$(($a + $b))
 echo "The sum of $a and $b is $result"
+```
+
+**Generating a QR Code**
+
+This example requires a tool like `qrencode` to be installed.
+
+```bash
+# Register a tool to generate a QR code
+mcp proxy tool qrcode "Generates a QR code" "text:string" \
+  -e 'echo -e "data:image/png;base64,$(qrencode -t png -o - "$text" | base64 -w 0)"'
 ```
 
 **Inline Command Example:**

--- a/cmd/mcptools/commands/version.go
+++ b/cmd/mcptools/commands/version.go
@@ -11,7 +11,7 @@ import (
 var Version = "dev"
 
 // getHomeDirectory returns the user's home directory
-// Tries HOME first, then falls back to USERPROFILE for Windows
+// Tries HOME first, then falls back to USERPROFILE for Windows.
 func getHomeDirectory() string {
 	homeDir := os.Getenv("HOME")
 	if homeDir == "" {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -501,6 +501,24 @@ func (s *Server) handleToolCall(params map[string]interface{}) (map[string]inter
 	s.log(fmt.Sprintf("Script output: %s", output))
 
 	// Return the output in the correct format for the MCP protocol
+	// Check if the output is a base64-encoded PNG image
+	// https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#image-content
+	if strings.HasPrefix(output, "data:image/png;base64,") {
+		base64Data := strings.TrimPrefix(output, "data:image/png;base64,")
+		return map[string]interface{}{
+			"content": []map[string]interface{}{
+				{
+					"type": "text",
+					"text": "generated PNG image",
+				},
+				{
+					"type":     "image",
+					"data":     base64Data,
+					"mimeType": "image/png",
+				},
+			},
+		}, nil
+	}
 	return map[string]interface{}{
 		"content": []map[string]interface{}{
 			{


### PR DESCRIPTION
# Description

Basic support for [ImageContent](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#image-content) response of MCP protocol.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Like in documented example with 'mcp web' interface

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
