### PR TITLE
Fix 405 error when connecting to servers requiring Accept header

### DIFF
--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -116,26 +116,24 @@ var CreateClientFunc = func(args []string, _ ...client.ClientOption) (*client.Cl
 			return nil, fmt.Errorf("failed to parse authentication: %w", authErr)
 		}
 
-		// Create headers map if authentication is provided
+		// Create headers map with required Accept header for MCP protocol
 		headers := make(map[string]string)
+
+		// Add authentication header if provided
 		if authHeader != "" {
 			headers["Authorization"] = authHeader
 		}
 
+		// Add Accept header required by MCP streamable HTTP and SSE transports
+		// Many MCP servers require clients to accept both JSON responses and event streams
+		headers["Accept"] = "application/json, text/event-stream"
+
 		if TransportOption == "sse" {
 			// For SSE transport, use transport.ClientOption
-			if len(headers) > 0 {
-				c, err = client.NewSSEMCPClient(cleanURL, transport.WithHeaders(headers))
-			} else {
-				c, err = client.NewSSEMCPClient(cleanURL)
-			}
+			c, err = client.NewSSEMCPClient(cleanURL, transport.WithHeaders(headers))
 		} else {
 			// For StreamableHTTP transport, use transport.StreamableHTTPCOption
-			if len(headers) > 0 {
-				c, err = client.NewStreamableHttpClient(cleanURL, transport.WithHTTPHeaders(headers))
-			} else {
-				c, err = client.NewStreamableHttpClient(cleanURL)
-			}
+			c, err = client.NewStreamableHttpClient(cleanURL, transport.WithHTTPHeaders(headers))
 		}
 
 		if err != nil {


### PR DESCRIPTION
## Problem

When attempting to connect to certain MCP servers like mcp.grep.app using streamable HTTP transport, mcptools returns a 405 error:

```
$ mcp tools https://mcp.grep.app
Error: unexpected status code: 405
```

This happens because some MCP servers require the client to include an Accept header that specifies support for both application/json and text/event-stream. Without this header, the server rejects the request.

## Solution

This PR modifies the HTTP and SSE transport setup to always include the required Accept header. The change is minimal and affects the header initialization in `cmd/mcptools/commands/utils.go`.

The fix also simplifies the existing logic by removing conditional header passing, since we now always have at least the Accept header to send.

## Testing

Verified the fix works with mcp.grep.app:

```bash
$ ./mcp tools https://mcp.grep.app
searchGitHub(query:str, [language:str[]], [matchCase:bool], ...)
    Find real-world code examples from over a million public GitHub repositories...
```

All existing unit tests continue to pass.