### PR TITLE
feat: add --timeout/-t flag for initialization timeout

### DIFF
--- a/cmd/mcptools/commands/call.go
+++ b/cmd/mcptools/commands/call.go
@@ -36,6 +36,11 @@ func parseCallArgs(cmdArgs []string) (string, []string) {
 		case (cmdArgs[i] == FlagAuthHeader) && i+1 < len(cmdArgs):
 			AuthHeader = cmdArgs[i+1]
 			i += 2
+		case (cmdArgs[i] == FlagTimeout || cmdArgs[i] == FlagTimeoutShort) && i+1 < len(cmdArgs):
+			if _, err := fmt.Sscanf(cmdArgs[i+1], "%d", &InitTimeout); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: invalid timeout value %q, using default\n", cmdArgs[i+1])
+			}
+			i += 2
 		case !entityExtracted:
 			entityName = cmdArgs[i]
 			entityExtracted = true

--- a/cmd/mcptools/commands/root.go
+++ b/cmd/mcptools/commands/root.go
@@ -9,16 +9,18 @@ import (
 
 // flags.
 const (
-	FlagFormat      = "--format"
-	FlagFormatShort = "-f"
-	FlagParams      = "--params"
-	FlagParamsShort = "-p"
-	FlagHelp        = "--help"
-	FlagHelpShort   = "-h"
-	FlagServerLogs  = "--server-logs"
-	FlagTransport   = "--transport"
-	FlagAuthUser    = "--auth-user"
-	FlagAuthHeader  = "--auth-header"
+	FlagFormat       = "--format"
+	FlagFormatShort  = "-f"
+	FlagParams       = "--params"
+	FlagParamsShort  = "-p"
+	FlagHelp         = "--help"
+	FlagHelpShort    = "-h"
+	FlagServerLogs   = "--server-logs"
+	FlagTransport    = "--transport"
+	FlagAuthUser     = "--auth-user"
+	FlagAuthHeader   = "--auth-header"
+	FlagTimeout      = "--timeout"
+	FlagTimeoutShort = "-t"
 )
 
 // entity types.
@@ -51,6 +53,8 @@ var (
 	AuthUser string
 	// AuthHeader is a custom Authorization header.
 	AuthHeader string
+	// InitTimeout is the timeout for MCP server initialization in seconds.
+	InitTimeout = 10
 )
 
 // RootCmd creates the root command.
@@ -68,6 +72,7 @@ It allows you to discover and call tools, list resources, and interact with MCP-
 	cmd.PersistentFlags().StringVar(&TransportOption, "transport", "http", "HTTP transport type (http, sse)")
 	cmd.PersistentFlags().StringVar(&AuthUser, "auth-user", "", "Basic authentication in username:password format")
 	cmd.PersistentFlags().StringVar(&AuthHeader, "auth-header", "", "Custom Authorization header (e.g., 'Bearer token' or 'Basic base64credentials')")
+	cmd.PersistentFlags().IntVarP(&InitTimeout, "timeout", "t", 10, "Initialization timeout in seconds")
 
 	return cmd
 }

--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -176,7 +177,7 @@ var CreateClientFunc = func(args []string, _ ...client.ClientOption) (*client.Cl
 		if err != nil {
 			return nil, fmt.Errorf("init error: %w", err)
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(time.Duration(InitTimeout) * time.Second):
 		return nil, fmt.Errorf("initialization timed out")
 	}
 
@@ -210,6 +211,11 @@ func ProcessFlags(args []string) []string {
 			i += 2
 		case args[i] == FlagAuthHeader && i+1 < len(args):
 			AuthHeader = args[i+1]
+			i += 2
+		case (args[i] == FlagTimeout || args[i] == FlagTimeoutShort) && i+1 < len(args):
+			if _, err := fmt.Sscanf(args[i+1], "%d", &InitTimeout); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: invalid timeout value %q, using default\n", args[i+1])
+			}
 			i += 2
 		default:
 			parsedArgs = append(parsedArgs, args[i])


### PR DESCRIPTION
Adds a configurable `--timeout` / `-t` flag for MCP server initialization timeout.

Default is 30 seconds. Useful when connecting to slow-starting servers.

## Changes
- Added `FlagTimeout`/`FlagTimeoutShort` constants and `InitTimeout` variable in `root.go`
- Added timeout flag parsing in `utils.go` and `call.go`
- Used in `CreateClientFunc()` for initialization timeout
- Added unit tests

## Usage
```bash
mcp call --timeout 60 ...  # 60 second timeout
mcp call -t 10 ...         # 10 second timeout
```