### PR TITLE
feat: add config source prefix syntax for loading servers from IDE configs

### DIFF
--- a/cmd/mcptools/commands/utils.go
+++ b/cmd/mcptools/commands/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -27,6 +28,77 @@ var (
 // IsHTTP returns true if the string is a valid HTTP URL.
 func IsHTTP(str string) bool {
 	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "localhost:")
+}
+
+// validConfigPrefixes defines the valid config source prefixes.
+var validConfigPrefixes = map[string]bool{
+	"vscode":          true,
+	"vscode-insiders": true,
+	"windsurf":        true,
+	"cursor":          true,
+	"claude-desktop":  true,
+	"claude-code":     true,
+}
+
+// ParseConfigPrefix parses a config source prefix from a server specification.
+// Examples:
+//
+//	"claude-code:firecrawl" -> ("claude-code", "firecrawl", true)
+//	"cursor:myserver"       -> ("cursor", "myserver", true)
+//	"myalias"               -> ("", "myalias", false)
+func ParseConfigPrefix(serverSpec string) (configSource, serverName string, hasPrefix bool) {
+	if idx := strings.Index(serverSpec, ":"); idx > 0 {
+		prefix := serverSpec[:idx]
+		if validConfigPrefixes[strings.ToLower(prefix)] {
+			return strings.ToLower(prefix), serverSpec[idx+1:], true
+		}
+	}
+	return "", serverSpec, false
+}
+
+// GetServerFromConfigSource loads a server configuration from a config source.
+// Returns the server config or an error if not found.
+func GetServerFromConfigSource(configSource, serverName string) (*ServerConfig, error) {
+	// Load the configs file to get the alias path
+	configs, err := loadConfigsFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configs: %w", err)
+	}
+
+	// Get the config alias
+	aliasConfig, ok := configs.Aliases[configSource]
+	if !ok {
+		return nil, fmt.Errorf("config source '%s' not found", configSource)
+	}
+
+	// Expand and read the config file
+	configPath := expandPath(aliasConfig.Path)
+
+	// Get servers using existing function based on JSONPath
+	var servers []ServerConfig
+	var scanErr error
+
+	if strings.Contains(aliasConfig.JSONPath, "mcp.servers") {
+		servers, scanErr = scanVSCodeConfig(configPath, aliasConfig.Source)
+	} else {
+		servers, scanErr = scanMCPServersConfig(configPath, aliasConfig.Source)
+	}
+
+	if scanErr != nil {
+		return nil, fmt.Errorf("failed to scan config: %w", scanErr)
+	}
+
+	// Find the specific server
+	var available []string
+	for _, server := range servers {
+		if server.Name == serverName {
+			return &server, nil
+		}
+		available = append(available, server.Name)
+	}
+
+	return nil, fmt.Errorf("server '%s' not found in %s\nAvailable servers: %s",
+		serverName, configSource, strings.Join(available, ", "))
 }
 
 // buildAuthHeader builds an Authorization header from the available auth options.
@@ -92,7 +164,33 @@ var CreateClientFunc = func(args []string, _ ...client.ClientOption) (*client.Cl
 		return nil, ErrCommandRequired
 	}
 
-	// Check if the first argument is an alias
+	// Check for config source prefix (e.g., "claude-code:firecrawl")
+	if len(args) == 1 {
+		configSource, serverName, hasPrefix := ParseConfigPrefix(args[0])
+		if hasPrefix {
+			serverConfig, err := GetServerFromConfigSource(configSource, serverName)
+			if err != nil {
+				return nil, err
+			}
+
+			// Build args from server config
+			if serverConfig.URL != "" {
+				// URL-based server (SSE/HTTP)
+				args = []string{serverConfig.URL}
+				// Note: Headers for SSE servers are not yet supported
+			} else {
+				// Stdio-based server
+				args = append([]string{serverConfig.Command}, serverConfig.Args...)
+			}
+
+			// Apply environment variables (errors are ignored as setenv rarely fails)
+			for key, value := range serverConfig.Env {
+				_ = os.Setenv(key, value)
+			}
+		}
+	}
+
+	// Check if the first argument is an alias (fallback if no prefix match)
 	if len(args) == 1 {
 		server, found := alias.GetServerCommand(args[0])
 		if found {

--- a/cmd/mcptools/commands/utils_test.go
+++ b/cmd/mcptools/commands/utils_test.go
@@ -190,3 +190,121 @@ nested  {"key":"value"}`[1:] // remove first newline
 		})
 	}
 }
+
+func TestParseConfigPrefix(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverSpec       string
+		wantConfigSource string
+		wantServerName   string
+		wantHasPrefix    bool
+	}{
+		{
+			name:             "claude-code prefix",
+			serverSpec:       "claude-code:firecrawl",
+			wantConfigSource: "claude-code",
+			wantServerName:   "firecrawl",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "claude-desktop prefix",
+			serverSpec:       "claude-desktop:playwright",
+			wantConfigSource: "claude-desktop",
+			wantServerName:   "playwright",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "cursor prefix",
+			serverSpec:       "cursor:myserver",
+			wantConfigSource: "cursor",
+			wantServerName:   "myserver",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "vscode prefix",
+			serverSpec:       "vscode:server",
+			wantConfigSource: "vscode",
+			wantServerName:   "server",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "vscode-insiders prefix",
+			serverSpec:       "vscode-insiders:server",
+			wantConfigSource: "vscode-insiders",
+			wantServerName:   "server",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "windsurf prefix",
+			serverSpec:       "windsurf:server",
+			wantConfigSource: "windsurf",
+			wantServerName:   "server",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "case insensitive prefix",
+			serverSpec:       "Claude-Code:firecrawl",
+			wantConfigSource: "claude-code",
+			wantServerName:   "firecrawl",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "no prefix - simple alias",
+			serverSpec:       "myalias",
+			wantConfigSource: "",
+			wantServerName:   "myalias",
+			wantHasPrefix:    false,
+		},
+		{
+			name:             "unknown prefix treated as no prefix",
+			serverSpec:       "unknown:server",
+			wantConfigSource: "",
+			wantServerName:   "unknown:server",
+			wantHasPrefix:    false,
+		},
+		{
+			name:             "HTTP URL not treated as prefix",
+			serverSpec:       "http://localhost:8080",
+			wantConfigSource: "",
+			wantServerName:   "http://localhost:8080",
+			wantHasPrefix:    false,
+		},
+		{
+			name:             "HTTPS URL not treated as prefix",
+			serverSpec:       "https://example.com",
+			wantConfigSource: "",
+			wantServerName:   "https://example.com",
+			wantHasPrefix:    false,
+		},
+		{
+			name:             "server name with colons",
+			serverSpec:       "claude-code:server:with:colons",
+			wantConfigSource: "claude-code",
+			wantServerName:   "server:with:colons",
+			wantHasPrefix:    true,
+		},
+		{
+			name:             "empty string",
+			serverSpec:       "",
+			wantConfigSource: "",
+			wantServerName:   "",
+			wantHasPrefix:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configSource, serverName, hasPrefix := ParseConfigPrefix(tt.serverSpec)
+
+			if configSource != tt.wantConfigSource {
+				t.Errorf("ParseConfigPrefix() configSource = %q, want %q", configSource, tt.wantConfigSource)
+			}
+			if serverName != tt.wantServerName {
+				t.Errorf("ParseConfigPrefix() serverName = %q, want %q", serverName, tt.wantServerName)
+			}
+			if hasPrefix != tt.wantHasPrefix {
+				t.Errorf("ParseConfigPrefix() hasPrefix = %v, want %v", hasPrefix, tt.wantHasPrefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add support for running MCP servers directly from IDE/editor configs using a prefix syntax like `claude-code:firecrawl` or `cursor:myserver`.

This loads the full server config (command, args, **env vars**) from the specified config source and runs the server with proper environment.

**Problem solved**: Previously, `mcp alias add` only stored the command string, losing environment variables. This feature lets users leverage their existing IDE configs without re-registering servers.

## Supported Prefixes

- `claude-code` (from `~/.claude.json`)
- `claude-desktop` (from Claude Desktop config)
- `cursor` (from Cursor settings)
- `vscode` / `vscode-insiders`
- `windsurf`

## Usage Examples

```bash
# Use firecrawl server from Claude Code config (with env vars!)
mcp tools claude-code:firecrawl

# Call a tool on a server from Cursor config
mcp call cursor:myserver tool_name --params '{"key": "value"}'

# Use playwright from Claude Desktop
mcp tools claude-desktop:playwright

# Mix with existing syntax
mcp tools claude-code:firecrawl   # From Claude config
mcp tools myalias                  # From aliases.json
mcp tools npx -y @mcp/server       # Direct command
```

## Changes

- Add `ParseConfigPrefix()` to parse `source:server` format
- Add `GetServerFromConfigSource()` to load server config from IDE configs
- Update `CreateClientFunc` to handle prefix syntax before alias lookup
- Add comprehensive unit tests for prefix parsing (13 test cases)

## Test Plan

- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Tested with real Claude Code config (`~/.claude.json`)
- [x] Verified env vars are properly passed to spawned server

## Notes

- Headers for SSE servers are not yet supported (noted in code)
- Uses existing `scanMCPServersConfig` and `scanVSCodeConfig` functions from `configs.go`